### PR TITLE
Add auto dark mode option (system follow)

### DIFF
--- a/app/static/js/settings.js
+++ b/app/static/js/settings.js
@@ -346,18 +346,37 @@ function sendSettingUpdateWithCallback(setting, value, callback) {
 }
 
 // --- Darkmode ---
-function toggleDarkmode() {
+function setDarkmode(value) {
     if (!navigator.onLine) {
         showSnackbar('settings', true, 'error', _('You are offline'), null, false);
         return;
     }
-    const toggle = document.getElementById('darkmode-toggle');
-    toggle.checked = !toggle.checked;
-    const value = toggle.checked ? 'TRUE' : 'FALSE';
 
-    document.body.classList.toggle('dark', toggle.checked);
+    const previousDark = document.body.classList.contains('dark');
 
-    // Re-apply accent color theme for new mode
+    if (value === 'AUTO') {
+        const prefersDark = window.matchMedia('(prefers-color-scheme: dark)').matches;
+        document.body.classList.toggle('dark', prefersDark);
+        if (!window.__autoDarkMqListener) {
+            window.__autoDarkMq = window.matchMedia('(prefers-color-scheme: dark)');
+            window.__autoDarkMqListener = async (e) => {
+                document.body.classList.toggle('dark', e.matches);
+                const accentHex = document.getElementById('input-custom-accent-color')?.value
+                    || document.querySelector('meta[name="theme-color"]')?.content;
+                if (accentHex && typeof window.applyTheme === 'function') {
+                    await window.applyTheme(accentHex);
+                }
+            };
+            window.__autoDarkMq.addEventListener('change', window.__autoDarkMqListener);
+        }
+    } else {
+        if (window.__autoDarkMq && window.__autoDarkMqListener) {
+            window.__autoDarkMq.removeEventListener('change', window.__autoDarkMqListener);
+            window.__autoDarkMqListener = null;
+        }
+        document.body.classList.toggle('dark', value === 'TRUE');
+    }
+
     const accentHex = document.getElementById('input-custom-accent-color')?.value
         || document.querySelector('meta[name="theme-color"]')?.content;
     if (accentHex && typeof window.applyTheme === 'function') {
@@ -378,15 +397,17 @@ function toggleDarkmode() {
                 showSnackbar('settings', true, 'green', result.message, null, false);
             } else {
                 showSnackbar('settings', true, 'error', result.message, result, true);
-                toggle.checked = !toggle.checked;
-                document.body.classList.toggle('dark', toggle.checked);
+                document.body.classList.toggle('dark', previousDark);
+                const sel = document.getElementById('darkmode-select');
+                if (sel) sel.value = previousDark ? 'TRUE' : 'FALSE';
             }
         })
         .catch((error) => {
             if (String(error) == "TypeError: Failed to fetch") error = _('Server not reachable');
             showSnackbar('settings', true, 'error', error, null, false);
-            toggle.checked = !toggle.checked;
-            document.body.classList.toggle('dark', toggle.checked);
+            document.body.classList.toggle('dark', previousDark);
+            const sel = document.getElementById('darkmode-select');
+            if (sel) sel.value = previousDark ? 'TRUE' : 'FALSE';
         });
 }
 

--- a/app/templates/layouts/head.html
+++ b/app/templates/layouts/head.html
@@ -11,8 +11,8 @@
 <!-- SortableJS (Drag & Drop) -->
 <script src="https://cdn.jsdelivr.net/npm/sortablejs@1.15.6/Sortable.min.js" defer></script>
 <!-- BeerCSS -->
-{% if accent_color and accent_color != '#6750A4' %}
-<style id="theme-cloak">body { opacity: 0; } body.theme-ready { opacity: 1; }</style>
+{% if (accent_color and accent_color != '#6750A4') or (darkmode and darkmode.value == 'AUTO') %}
+<style id="theme-cloak">body { opacity: 0; } body.theme-ready { opacity: 1; transition: opacity 0.05s; }</style>
 {% endif %}
 <link href="https://cdn.jsdelivr.net/npm/beercss@3.6.13/dist/cdn/beer.min.css" rel="stylesheet">
 <script type="module" src="https://cdn.jsdelivr.net/npm/beercss@3.6.13/dist/cdn/beer.min.js"></script>
@@ -21,9 +21,28 @@
 <script type="module">
   window.applyTheme = async (hex) => await ui('theme', hex);
   const accentColor = '{{ accent_color|default("#6750A4") }}';
-  if (accentColor && accentColor !== '#6750A4') {
+  const darkmodeValue = '{{ darkmode.value if darkmode else "FALSE" }}';
+
+  if (darkmodeValue === 'AUTO') {
+    const mq = window.matchMedia('(prefers-color-scheme: dark)');
+    document.body.classList.toggle('dark', mq.matches);
+    if (accentColor && accentColor !== '#6750A4') {
+      await ui('theme', accentColor);
+    }
+    window.__autoDarkMq = mq;
+    window.__autoDarkMqListener = async (e) => {
+      document.body.classList.toggle('dark', e.matches);
+      const currentAccent = document.getElementById('input-custom-accent-color')?.value
+        || document.querySelector('meta[name="theme-color"]')?.content;
+      if (currentAccent && typeof window.applyTheme === 'function') {
+        await window.applyTheme(currentAccent);
+      }
+    };
+    mq.addEventListener('change', window.__autoDarkMqListener);
+  } else if (accentColor && accentColor !== '#6750A4') {
     await ui('theme', accentColor);
   }
+
   document.body.classList.add('theme-ready');
   const cloak = document.getElementById('theme-cloak');
   if (cloak) cloak.remove();

--- a/app/templates/pages/settings.html
+++ b/app/templates/pages/settings.html
@@ -283,7 +283,7 @@
 
               {% for user_setting in user_settings %}
               {% if user_setting.name == 'darkmode' %}
-              <div class="row padding primary-container" style="border-radius: 0.75rem; align-items: center;">
+              <div class="row padding primary-container" style="margin:0;">
                 <i>{{ user_setting.icon }}</i>
                 <div class="max">
                   <h6 class="small">{{ _(user_setting.name) }}</h6>

--- a/app/templates/pages/settings.html
+++ b/app/templates/pages/settings.html
@@ -283,16 +283,20 @@
 
               {% for user_setting in user_settings %}
               {% if user_setting.name == 'darkmode' %}
-              <a class="row padding primary-container wave" onclick="toggleDarkmode()">
+              <div class="row padding primary-container" style="border-radius: 0.75rem; align-items: center;">
                 <i>{{ user_setting.icon }}</i>
                 <div class="max">
-                  <h6 class="small" id="{{ user_setting.name }}-name">{{ _(user_setting.name) }}</h6>
+                  <h6 class="small">{{ _(user_setting.name) }}</h6>
                 </div>
-                <label class="switch">
-                  <input type="checkbox" id="darkmode-toggle" {{ 'checked' if user_setting.value == 'TRUE' }}>
-                  <span></span>
-                </label>
-              </a>
+                <div class="field suffix border" style="min-width:9rem; margin:0;">
+                  <select id="darkmode-select" onchange="setDarkmode(this.value)">
+                    <option value="FALSE" {% if user_setting.value == 'FALSE' %}selected{% endif %}>{{ _('Light') }}</option>
+                    <option value="TRUE" {% if user_setting.value == 'TRUE' %}selected{% endif %}>{{ _('Dark') }}</option>
+                    <option value="AUTO" {% if user_setting.value == 'AUTO' %}selected{% endif %}>{{ _('System') }}</option>
+                  </select>
+                  <i>arrow_drop_down</i>
+                </div>
+              </div>
               {% elif user_setting.name == 'language' %}
               <a class="row padding primary-container wave" onclick="editSetting('{{user_setting.name}}', 'language')">
                 <i>{{ user_setting.icon }}</i>

--- a/app/translations/de-DE.json
+++ b/app/translations/de-DE.json
@@ -4198,5 +4198,21 @@
         "languageCode": "de-DE",
         "entityType": "ui",
         "translatedText": "Falls du dies nicht angefordert hast, kannst du diese E-Mail ignorieren."
+    },
+    {
+        "entityID": 0,
+        "fieldName": "Light",
+        "helpText": "",
+        "languageCode": "de-DE",
+        "entityType": "ui",
+        "translatedText": "Hell"
+    },
+    {
+        "entityID": 0,
+        "fieldName": "Dark",
+        "helpText": "",
+        "languageCode": "de-DE",
+        "entityType": "ui",
+        "translatedText": "Dunkel"
     }
 ]

--- a/app/translations/en-US.json
+++ b/app/translations/en-US.json
@@ -4198,5 +4198,21 @@
         "languageCode": "en-US",
         "entityType": "ui",
         "translatedText": "If you did not request this, you can ignore this e-mail."
+    },
+    {
+        "entityID": 0,
+        "fieldName": "Light",
+        "helpText": "",
+        "languageCode": "en-US",
+        "entityType": "ui",
+        "translatedText": "Light"
+    },
+    {
+        "entityID": 0,
+        "fieldName": "Dark",
+        "helpText": "",
+        "languageCode": "en-US",
+        "entityType": "ui",
+        "translatedText": "Dark"
     }
 ]

--- a/app/translations/it-IT.json
+++ b/app/translations/it-IT.json
@@ -4198,5 +4198,21 @@
         "languageCode": "it-IT",
         "entityType": "ui",
         "translatedText": "Se non hai richiesto questa operazione, puoi ignorare questa email."
+    },
+    {
+        "entityID": 0,
+        "fieldName": "Light",
+        "helpText": "",
+        "languageCode": "it-IT",
+        "entityType": "ui",
+        "translatedText": "Chiaro"
+    },
+    {
+        "entityID": 0,
+        "fieldName": "Dark",
+        "helpText": "",
+        "languageCode": "it-IT",
+        "entityType": "ui",
+        "translatedText": "Scuro"
     }
 ]


### PR DESCRIPTION
Closes #11

  ## Changes
  - Replace dark mode toggle with a dropdown (Light / Dark / System)
  - System mode follows \`prefers-color-scheme\` in real time
  - FOUC prevention via opacity cloak when system mode is active
  - Translation keys added for Light / Dark in de-DE, en-US, it-IT"